### PR TITLE
✨ step4: kafka streams 조인 사용해보기

### DIFF
--- a/DockerKafka/docker-compose.yml
+++ b/DockerKafka/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - "9092:9092"
     environment:
       KAFKA_ADVERTISED_HOST_NAME: localhost
-      KAFKA_CREATE_TOPICS: "kvp-input:1:1,kvp-output:1:1,developer:1:1,junior-developer:1:1,senior-developer:1:1,senior-java-developer:1:1,customer:1:1,purchase-customer:1:1"
+      KAFKA_CREATE_TOPICS: "kvp-input:1:1,kvp-output:1:1,developer:1:1,junior-developer:1:1,senior-developer:1:1,senior-java-developer:1:1,customer:1:1,purchase-customer:1:1,work-log:1:1,daily-work-log:1:1,over-work-log:1:1"
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/http/simpleProduce.http
+++ b/http/simpleProduce.http
@@ -7,3 +7,7 @@ http://localhost:8080/kafka/developer?name=김혜린&age=27&language=JAVA&year=4
 http://localhost:8080/kafka/developer?name=박선영&age=27&language=Typescript&year=4
 ###
 http://localhost:8080/kafka/customer?name=박선영&purchaseAmount=100000
+###
+http://localhost:8080/kafka/work-log?no=1&name=박선영&workType=WORK&dateTime=2021-09-09 10:00:00
+###
+http://localhost:8080/kafka/work-log?no=1&name=박선영&workType=OFF_WORK&dateTime=2021-09-09 21:30:00

--- a/kvp-domain/src/main/java/com.kvp.domain/DailyWorkLog.java
+++ b/kvp-domain/src/main/java/com.kvp.domain/DailyWorkLog.java
@@ -1,0 +1,28 @@
+package com.kvp.domain;
+
+import java.time.Duration;
+import java.time.LocalDate;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class DailyWorkLog {
+    private static int BASE_WORK_HOUR = 9;
+    private Employee employee;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate workDate;
+    private long workHour;
+
+    public boolean isOverWork() {
+        return getOverWorkTime() > 0L;
+    }
+
+    public long getOverWorkTime() {
+        return workHour - BASE_WORK_HOUR;
+    }
+}

--- a/kvp-domain/src/main/java/com.kvp.domain/Employee.java
+++ b/kvp-domain/src/main/java/com.kvp.domain/Employee.java
@@ -1,0 +1,13 @@
+package com.kvp.domain;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class Employee {
+    private Long no;
+    private String name;
+}

--- a/kvp-domain/src/main/java/com.kvp.domain/OverWorkLog.java
+++ b/kvp-domain/src/main/java/com.kvp.domain/OverWorkLog.java
@@ -1,0 +1,18 @@
+package com.kvp.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class OverWorkLog {
+    private Employee employee;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate workDate;
+    private long overWorkTime;
+}

--- a/kvp-domain/src/main/java/com.kvp.domain/WorkLog.java
+++ b/kvp-domain/src/main/java/com.kvp.domain/WorkLog.java
@@ -1,0 +1,28 @@
+package com.kvp.domain;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.*;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class WorkLog {
+    private Employee employee;
+    private WorkType workType;
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime  workDateTime;
+
+    public boolean isWork() {
+        return workType == WorkType.WORK;
+    }
+
+    public boolean isOffWork() {
+        return workType == WorkType.OFF_WORK;
+    }
+}

--- a/kvp-domain/src/main/java/com.kvp.domain/WorkType.java
+++ b/kvp-domain/src/main/java/com.kvp.domain/WorkType.java
@@ -1,0 +1,6 @@
+package com.kvp.domain;
+
+public enum WorkType {
+    WORK,
+    OFF_WORK,
+}

--- a/kvp-kafka/src/main/java/com/kvp/kafka/consumer/ConsumerConfiguration.java
+++ b/kvp-kafka/src/main/java/com/kvp/kafka/consumer/ConsumerConfiguration.java
@@ -1,10 +1,8 @@
 package com.kvp.kafka.consumer;
 
-import com.kvp.domain.Customer;
-import com.kvp.domain.Developer;
-import com.kvp.domain.Introduce;
-import com.kvp.domain.SimpleDeveloper;
+import com.kvp.domain.*;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -72,6 +70,34 @@ public class ConsumerConfiguration {
     public ConcurrentKafkaListenerContainerFactory<String, Customer> customerListener() {
         ConcurrentKafkaListenerContainerFactory<String, Customer> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(customerConsumerConfigs());
+        return factory;
+    }
+
+    public ConsumerFactory<Long, DailyWorkLog> dailyWorkLogConsumerConfigs() {
+        return new DefaultKafkaConsumerFactory<>(
+                getConfigs("work-log"),
+                new LongDeserializer(),
+                new JsonDeserializer<>(DailyWorkLog.class));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<Long, DailyWorkLog> dailyWorkLogListener() {
+        ConcurrentKafkaListenerContainerFactory<Long, DailyWorkLog> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(dailyWorkLogConsumerConfigs());
+        return factory;
+    }
+
+    public ConsumerFactory<Long, OverWorkLog> overWorkLogConsumerConfigs() {
+        return new DefaultKafkaConsumerFactory<>(
+                getConfigs("work-log"),
+                new LongDeserializer(),
+                new JsonDeserializer<>(OverWorkLog.class));
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<Long, OverWorkLog> overWorkLogListener() {
+        ConcurrentKafkaListenerContainerFactory<Long, OverWorkLog> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(overWorkLogConsumerConfigs());
         return factory;
     }
 

--- a/kvp-kafka/src/main/java/com/kvp/kafka/consumer/WorkLogConsumer.java
+++ b/kvp-kafka/src/main/java/com/kvp/kafka/consumer/WorkLogConsumer.java
@@ -1,0 +1,21 @@
+package com.kvp.kafka.consumer;
+
+import com.kvp.domain.DailyWorkLog;
+import com.kvp.domain.OverWorkLog;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class WorkLogConsumer {
+    @KafkaListener(topics = "daily-work-log", groupId = "work-log", containerFactory = "dailyWorkLogListener")
+    public void consumeWorkLog(DailyWorkLog dailyWorkLog) {
+        log.info("날짜별 근무 기록 consumer message: {}", dailyWorkLog);
+    }
+
+    @KafkaListener(topics = "over-work-log", groupId = "work-log", containerFactory = "overWorkLogListener")
+    public void consumeOverWorkLog(OverWorkLog overWorkLog) {
+        log.info("초과 근무 기록 consumer message: {}", overWorkLog);
+    }
+}

--- a/kvp-kafka/src/main/java/com/kvp/kafka/controller/KafkaController.java
+++ b/kvp-kafka/src/main/java/com/kvp/kafka/controller/KafkaController.java
@@ -1,17 +1,18 @@
 package com.kvp.kafka.controller;
 
-import com.kvp.domain.Developer;
-import com.kvp.domain.Introduce;
-import com.kvp.domain.Language;
-import com.kvp.domain.PurchaseCustomer;
+import com.kvp.domain.*;
 import com.kvp.kafka.producer.DeveloperProducer;
 import com.kvp.kafka.producer.KvpTestProducer;
 import com.kvp.kafka.producer.PurchaseCustomerProducer;
+import com.kvp.kafka.producer.WorkLogProducer;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/kafka")
@@ -20,6 +21,7 @@ public class KafkaController {
     private final KvpTestProducer kvpTestProducer;
     private final DeveloperProducer developerProducer;
     private final PurchaseCustomerProducer purchaseCustomerProducer;
+    private final WorkLogProducer workLogProducer;
 
     @GetMapping
     public ResponseEntity send(String name, Long age) {
@@ -39,6 +41,14 @@ public class KafkaController {
     public ResponseEntity sendCustomer(String name, Long purchaseAmount) {
         PurchaseCustomer purchaseCustomer = new PurchaseCustomer(name, purchaseAmount);
         purchaseCustomerProducer.send(purchaseCustomer);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/work-log")
+    public ResponseEntity sendWorkLog(Long no, String name, WorkType workType,
+                                      @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss") LocalDateTime dateTime) {
+        WorkLog workLog = new WorkLog(new Employee(no, name), workType, dateTime);
+        workLogProducer.send(workLog);
         return ResponseEntity.ok().build();
     }
 }

--- a/kvp-kafka/src/main/java/com/kvp/kafka/producer/KafkaProducerConfiguration.java
+++ b/kvp-kafka/src/main/java/com/kvp/kafka/producer/KafkaProducerConfiguration.java
@@ -3,6 +3,7 @@ package com.kvp.kafka.producer;
 import com.kvp.domain.Developer;
 import com.kvp.domain.Introduce;
 import com.kvp.domain.PurchaseCustomer;
+import com.kvp.domain.WorkLog;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.context.annotation.Bean;
@@ -43,6 +44,15 @@ public class KafkaProducerConfiguration {
     @Bean
     public KafkaTemplate<String, PurchaseCustomer> purchaseCustomerKafkaTemplate() {
         return new KafkaTemplate<>(purchaseCustomerProducerFactory());
+    }
+
+    public ProducerFactory<Long, WorkLog> workLogProducerFactory() {
+        return new DefaultKafkaProducerFactory<>(getPropsWithStringKeyAndJsonValue());
+    }
+
+    @Bean
+    public KafkaTemplate<Long, WorkLog> workLogKafkaTemplate() {
+        return new KafkaTemplate<>(workLogProducerFactory());
     }
 
     private static Map<String, Object> getPropsWithStringKeyAndJsonValue() {

--- a/kvp-kafka/src/main/java/com/kvp/kafka/producer/WorkLogProducer.java
+++ b/kvp-kafka/src/main/java/com/kvp/kafka/producer/WorkLogProducer.java
@@ -1,0 +1,23 @@
+package com.kvp.kafka.producer;
+
+import com.kvp.domain.PurchaseCustomer;
+import com.kvp.domain.WorkLog;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class WorkLogProducer {
+    private static final String TOPIC = "work-log";
+    private final KafkaTemplate<Long, WorkLog> kafkaTemplate;
+
+    public WorkLogProducer(KafkaTemplate<Long, WorkLog> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void send(WorkLog workLog) {
+        log.info("출/퇴근 기록 message : {}", workLog);
+        kafkaTemplate.send(TOPIC, workLog);
+    }
+}

--- a/kvp-streams/build.gradle
+++ b/kvp-streams/build.gradle
@@ -2,4 +2,5 @@ group = 'com.kvp.kafka-streams'
 
 dependencies {
     implementation project(':kvp-domain')
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }

--- a/kvp-streams/src/main/java/com/kvp/streams/joiner/WorkLogJoiner.java
+++ b/kvp-streams/src/main/java/com/kvp/streams/joiner/WorkLogJoiner.java
@@ -1,0 +1,17 @@
+package com.kvp.streams.joiner;
+
+import com.kvp.domain.DailyWorkLog;
+import com.kvp.domain.WorkLog;
+import org.apache.kafka.streams.kstream.ValueJoiner;
+
+import java.time.Duration;
+
+public class WorkLogJoiner implements ValueJoiner<WorkLog, WorkLog, DailyWorkLog> {
+
+    @Override
+    public DailyWorkLog apply(WorkLog workLog, WorkLog offWorkLog) {
+        return new DailyWorkLog(workLog.getEmployee(),
+                workLog.getWorkDateTime().toLocalDate(),
+                Duration.between(workLog.getWorkDateTime(), offWorkLog.getWorkDateTime()).toHours());
+    }
+}

--- a/kvp-streams/src/main/java/com/kvp/streams/serdes/DailyWorkLogSerde.java
+++ b/kvp-streams/src/main/java/com/kvp/streams/serdes/DailyWorkLogSerde.java
@@ -1,0 +1,12 @@
+package com.kvp.streams.serdes;
+
+import com.kvp.domain.DailyWorkLog;
+import org.apache.kafka.common.serialization.Serdes;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+public class DailyWorkLogSerde extends Serdes.WrapperSerde<DailyWorkLog> {
+    public DailyWorkLogSerde() {
+        super(new JsonSerializer<>(), new JsonDeserializer<>(DailyWorkLog.class));
+    }
+}

--- a/kvp-streams/src/main/java/com/kvp/streams/serdes/OverWorkLogSerde.java
+++ b/kvp-streams/src/main/java/com/kvp/streams/serdes/OverWorkLogSerde.java
@@ -1,0 +1,12 @@
+package com.kvp.streams.serdes;
+
+import com.kvp.domain.OverWorkLog;
+import org.apache.kafka.common.serialization.Serdes;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+public class OverWorkLogSerde extends Serdes.WrapperSerde<OverWorkLog> {
+    public OverWorkLogSerde() {
+        super(new JsonSerializer<>(), new JsonDeserializer<>(OverWorkLog.class));
+    }
+}

--- a/kvp-streams/src/main/java/com/kvp/streams/serdes/WorkLogSerde.java
+++ b/kvp-streams/src/main/java/com/kvp/streams/serdes/WorkLogSerde.java
@@ -1,0 +1,12 @@
+package com.kvp.streams.serdes;
+
+import com.kvp.domain.WorkLog;
+import org.apache.kafka.common.serialization.Serdes;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+public class WorkLogSerde extends Serdes.WrapperSerde<WorkLog> {
+    public WorkLogSerde() {
+        super(new JsonSerializer<>(), new JsonDeserializer<>(WorkLog.class));
+    }
+}


### PR DESCRIPTION
- 조인 사용해보기
- 요구사항
  - 필수사항
    - 직원 출/퇴근 기록을 입력값으로 받는다.
    - 출근/퇴근 값을 기준으로 분기한다.
    - 출근 기록이 찍힌 이후 24시간 내에 퇴근 기록이 입력되어야 조인할 수 있다.
    - 출근 기록과 퇴근 기록을 조인해 하루 근무 시간을 구한다.

  - 선택사항
    - 기본 근무시간을 초과한 직원을 필터링한다.
    - 기본 근무시간은 1일 9시간이다.
    - 초과 근무자의 초과 근무 시간을 기록한다.